### PR TITLE
Removes johnsnowlabs and prepares for 1.5.0

### DIFF
--- a/01_Introduction_And_Setup.py
+++ b/01_Introduction_And_Setup.py
@@ -3,7 +3,13 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install johnsnowlabs==4.2.3 networkx==2.5 decorator==5.0.9 plotly==5.1.0 
+# MAGIC %md # Preinstallation
+# MAGIC `johnsnowlabs` should come installed in your cluster. Just in case it is not, we install it.
+# MAGIC We also install visualization libraries for rendering the graph.
+
+# COMMAND ----------
+
+# MAGIC %pip install -q networkx==2.5 decorator==5.0.9 plotly==5.1.0
 
 # COMMAND ----------
 
@@ -67,17 +73,8 @@ print(f"Spark NLP PySpark: {johnsnowlabs.settings.raw_version_pyspark}")
 
 # COMMAND ----------
 
-# MAGIC %md
-# MAGIC Let's install the graph and visualization libraries
-
-# COMMAND ----------
-
-!pip install -q networkx==2.5 decorator==5.0.9 plotly==5.1.0
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC Let's import them and reload, in case other versions of the libraries were present
+# MAGIC %md ## Visualization Libraries
+# MAGIC Checking they are installed, reimporting them
 
 # COMMAND ----------
 

--- a/02_10K_Analysis.py
+++ b/02_10K_Analysis.py
@@ -3,7 +3,13 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install johnsnowlabs==4.2.3 networkx==2.5 decorator==5.0.9 plotly==5.1.0 
+# MAGIC %md # Preinstallation
+# MAGIC `johnsnowlabs` should come installed in your cluster. Just in case it is not, we install it.
+# MAGIC We also install visualization libraries for rendering the graph.
+
+# COMMAND ----------
+
+# MAGIC %pip install -q networkx==2.5 decorator==5.0.9 plotly==5.1.0 
 
 # COMMAND ----------
 

--- a/03_Named_Entity_Recognition.py
+++ b/03_Named_Entity_Recognition.py
@@ -3,7 +3,14 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install johnsnowlabs==4.2.3 networkx==2.5 decorator==5.0.9 plotly==5.1.0 
+# MAGIC %md 
+# MAGIC # Preinstallation
+# MAGIC `johnsnowlabs` should come installed in your cluster. Just in case it is not, we install it.
+# MAGIC We also install visualization libraries for rendering the graph.%md
+
+# COMMAND ----------
+
+# MAGIC %pip install networkx==2.5 decorator==5.0.9 plotly==5.1.0 
 
 # COMMAND ----------
 

--- a/05_Relation_Extraction.py
+++ b/05_Relation_Extraction.py
@@ -3,7 +3,14 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install johnsnowlabs==4.2.3 networkx==2.5 decorator==5.0.9 plotly==5.1.0 
+# MAGIC %md 
+# MAGIC # Preinstallation
+# MAGIC `johnsnowlabs` should come installed in your cluster. Just in case it is not, we install it.
+# MAGIC We also install visualization libraries for rendering the graph.
+
+# COMMAND ----------
+
+# MAGIC %pip install networkx==2.5 decorator==5.0.9 plotly==5.1.0 
 
 # COMMAND ----------
 

--- a/06_Understanding_Entities_in_Context.py
+++ b/06_Understanding_Entities_in_Context.py
@@ -3,7 +3,14 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install johnsnowlabs==4.2.3 networkx==2.5 decorator==5.0.9 plotly==5.1.0 
+# MAGIC %md 
+# MAGIC # Preinstallation
+# MAGIC `johnsnowlabs` should come installed in your cluster. Just in case it is not, we install it.
+# MAGIC We also install visualization libraries for rendering the graph.
+
+# COMMAND ----------
+
+# MAGIC %pip install networkx==2.5 decorator==5.0.9 plotly==5.1.0 
 
 # COMMAND ----------
 


### PR DESCRIPTION
Fixes:
- `johnsnowlabs==4.3.0` should not be in the pip install because it should take the version of the cluster. We make sure in the cluster provision that the version is the latest one. If we keep 4.3.0, it will be downgrading.
- Prepares for 1.5.0 where one small piece of code may be breaking. This commit also fixes that so that it does not break in the future.